### PR TITLE
Accept constraint senses as a Series or column

### DIFF
--- a/src/gurobipy_pandas/accessors.py
+++ b/src/gurobipy_pandas/accessors.py
@@ -165,7 +165,8 @@ class GRBDataFrameAccessor:
             A string representation of the entire constraint
             expression, or the name of a column
         sense : str, optional
-            Constraint sense. Required if lhs is not a complete
+            Constraint sense. Can be a column name or a string value
+            representing the sense. Required if lhs is not a complete
             expression including a comparator
         rhs : str or float, optional
             Constraint right hand side. Can be a column name or

--- a/src/gurobipy_pandas/api.py
+++ b/src/gurobipy_pandas/api.py
@@ -177,7 +177,7 @@ def add_vars(
 def add_constrs(
     model: gp.Model,
     lhs: Union[pd.Series, float],
-    sense: str,
+    sense: Union[pd.Series, str],
     rhs: Union[pd.Series, float],
     *,
     name: Optional[str] = None,
@@ -191,8 +191,9 @@ def add_constrs(
         A Gurobi model to which new constraints will be added
     lhs : Series
         A series of expressions forming the left hand side of constraints
-    sense : str
-        Constraint sense
+    sense : Series or str
+        Constraint sense; can be a series if senses vary, or a single string
+        if all constraints have the same sense
     rhs : Series or float
         A series of expressions forming the right hand side of constraints,
         or a common constant

--- a/src/gurobipy_pandas/constraints.py
+++ b/src/gurobipy_pandas/constraints.py
@@ -81,7 +81,6 @@ def add_constrs_from_series(
         data = pd.DataFrame({"lhs": lhs, "sense": sense, "rhs": rhs})
         sense = "sense"
     else:
-        assert isinstance(sense, str)
         data = pd.DataFrame({"lhs": lhs, "rhs": rhs})
 
     return add_constrs_from_dataframe(
@@ -137,7 +136,7 @@ def _add_constr(model, lhs, sense, rhs, name):
     function depending on the expression type."""
     if name is None:
         name = ""
-    if sense[0] not in CONSTRAINT_SENSES:
+    if not isinstance(sense, str) or sense[0] not in CONSTRAINT_SENSES:
         raise ValueError(f"'{sense}' is not a valid constraint sense")
     if isinstance(lhs, gp.QuadExpr) or isinstance(rhs, gp.QuadExpr):
         return model.addQConstr(lhs, sense, rhs, name=name)
@@ -188,7 +187,6 @@ def _add_constrs_from_dataframe_args(
     # sense character (i.e. '<', '>', or '=') then use it as the sense for
     # all constraints. Otherwise, assume it is a column name in the input
     # dataframe and take the sense strings from that column.
-    assert isinstance(sense, str)
     if sense in data.columns:
         sense_index = list(data.columns).index(sense)
         sense_value = lambda row: row[sense_index]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -269,6 +269,32 @@ class TestAddConstrs(GurobiModelTestCase):
             self.assertEqual(constr.RHS, -1.0)
 
 
+class TestDataValidation(GurobiModelTestCase):
+    # Test that we throw some more informative errors, instead of obscure
+    # ones from the underlying gurobipy library
+
+    def test_bad_sense_1(self):
+        index = pd.Index(["a", "e", "g"])
+
+        x = gppd.add_vars(self.model, index, name="x")
+        y = gppd.add_vars(self.model, index, name="y")
+
+        with self.assertRaisesRegex(
+            ValueError, "'less' is not a valid constraint sense"
+        ):
+            gppd.add_constrs(self.model, x, "less", y)
+
+    def test_bad_sense_2(self):
+        index = pd.Index(["a", "e", "g"])
+
+        x = gppd.add_vars(self.model, index, name="x")
+        y = gppd.add_vars(self.model, index, name="y")
+        sense = pd.Series(index=index, data=["<=", "a", "="])
+
+        with self.assertRaisesRegex(ValueError, "'a' is not a valid constraint sense"):
+            gppd.add_constrs(self.model, x, sense, y)
+
+
 class TestNonInteractiveMode(GurobiModelTestCase):
     # Check that no updates are run by default.
     # Test all add_vars / add_constrs entry points.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -294,6 +294,17 @@ class TestDataValidation(GurobiModelTestCase):
         with self.assertRaisesRegex(ValueError, "'a' is not a valid constraint sense"):
             gppd.add_constrs(self.model, x, sense, y)
 
+    def test_bad_sense_3(self):
+        index = pd.Index(["a", "e", "g"])
+
+        x = gppd.add_vars(self.model, index, name="x")
+        y = gppd.add_vars(self.model, index, name="y")
+
+        with self.assertRaisesRegex(
+            ValueError, "'3.5' is not a valid constraint sense"
+        ):
+            gppd.add_constrs(self.model, x, 3.5, y)
+
 
 class TestNonInteractiveMode(GurobiModelTestCase):
     # Check that no updates are run by default.

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -442,6 +442,25 @@ class TestAddConstrsFromSeries(GurobiModelTestCase):
         with self.assertRaises(ValueError):
             add_constrs_from_series(self.model, a, GRB.EQUAL, y)
 
+    def test_sense_series(self):
+        index = pd.RangeIndex(5)
+        x = add_vars_from_index(self.model, index)
+        y = add_vars_from_index(self.model, index)
+        sense = pd.Series(index=index, data=list("<=>=<"), dtype=object)
+
+        constrs = add_constrs_from_series(self.model, x + 1, sense, y)
+
+        self.model.update()
+        self.assertEqual(self.model.NumConstrs, 5)
+
+        self.assertIsInstance(constrs, pd.Series)
+        assert_index_equal(constrs.index, index)
+
+        for i in index:
+            self.assertEqual(constrs[i].Sense, sense[i])
+            self.assertEqual(constrs[i].RHS, -1.0)
+            self.assert_linexpr_equal(self.model.getRow(constrs[i]), x[i] - y[i])
+
 
 class TestExpressionParser(unittest.TestCase):
     # Check correctness against pd.DataFrame.eval for some numeric data


### PR DESCRIPTION
Implements #58, so users can do:

```
import pandas as pd
import gurobipy as gp
import gurobipy_pandas as gppd


data = pd.DataFrame(
    {
        "bound": ["upper", "lower", "eq", "upper", "lower"],
        "a": [1.0, 2.0, -3.0, 4.0, -5.0],
        "b": [5.0, -4.0, 3.0, -2.0, 1.0],
        "c": [1.1, -2.1, 3.6, -1.5, 1.2],
    }
)


with gp.Env() as env, gp.Model(env=env) as model:
    frame = (
        data.gppd.add_vars(model, name="x")
        .gppd.add_vars(model, name="y")
        .assign(
            lhs=lambda df: df["a"] * df["x"] + df["b"] * df["y"],
            sense=lambda df: df["bound"].map({"lower": ">", "upper": "<", "eq": "="}),
        )
        .gppd.add_constrs(model, lhs="lhs", sense="sense", rhs="c", name="constr")
    )
    model.write("model1.lp")
```

or:

```
with gp.Env() as env, gp.Model(env=env) as model:
    x = gppd.add_vars(model, data.index, name="x")
    y = gppd.add_vars(model, data.index, name="y")
    constrs = gppd.add_constrs(
        model,
        data["a"] * x + data["b"] * y,
        data["bound"].map({"lower": ">", "upper": "<", "eq": "="}),
        data["c"],
        name="constr",
    )
    model.write("model2.lp")
```

to produce the following LP:

```
\ LP format - for model browsing. Use MPS format to capture full model detail.
Minimize
 
Subject To
 constr[0]: x[0] + 5 y[0] <= 1.1
 constr[1]: 2 x[1] - 4 y[1] >= -2.1
 constr[2]: - 3 x[2] + 3 y[2] = 3.6
 constr[3]: 4 x[3] - 2 y[3] <= -1.5
 constr[4]: - 5 x[4] + y[4] >= 1.2
Bounds
End
```