### PR TITLE
Support nonlinear constraints with Gurobi 12

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,6 +78,7 @@ If you encounter issues with Gurobi or ``gurobipy`` please contact
 
    performance
    naming
+   nonlinear
    advanced
    typing
 

--- a/docs/source/nonlinear.rst
+++ b/docs/source/nonlinear.rst
@@ -4,7 +4,7 @@ Adding Nonlinear Constraints
 Gurobi 12 supports adding nonlinear constraints, using the ``NLExpr`` object to
 capture nonlinear expressions. ``gurobipy-pandas`` supports adding a ``Series``
 of nonlinear constraints to a model via ``add_constrs``. Note that ``gurobipy``
-only supports nonlinear constraints of the form :math:`y = f(x)`, and
+only supports nonlinear constraints of the form :math:`y = f(\bar{x})` and
 ``gurobipy-pandas`` applies the same restriction.
 
 .. note::
@@ -15,8 +15,8 @@ only supports nonlinear constraints of the form :math:`y = f(x)`, and
 Nonlinear Equality Constraints
 ------------------------------
 
-This example builds the constraint set :math:`y_i = \log(x_i)`, for each
-:math:`i` in the index.
+This example builds the constraint set :math:`y_i = \log(\frac{1}{x_i})`, for
+each :math:`i` in the index.
 
 .. doctest:: [nonlinear]
 
@@ -29,44 +29,47 @@ This example builds the constraint set :math:`y_i = \log(x_i)`, for each
 
     >>> model = gp.Model()
     >>> index = pd.RangeIndex(5)
-    >>> x = gppd.add_vars(model, index, name="x")
-    >>> y = gppd.add_vars(model, index, name="y")
+    >>> x = gppd.add_vars(model, index, lb=1.0, name="x")
+    >>> y = gppd.add_vars(model, index, lb=-GRB.INFINITY, name="y")
 
-The ``nlfunc`` module of gurobipy is used to create nonlinear expressions. You
-can use ``apply`` to construct a series representing the logarithm of each
-variable in the series:
+You can create nonlinear expressions using standard Python operators. A
+nonlinear expression is any expression which is not a polynomial of degree at
+most 2. For example, dividing a constant by a series of ``Var`` objects produces
+a series of nonlinear expressions.
 
 .. doctest:: [nonlinear]
 
-   >>> x.apply(nlfunc.log)
-   0    log(x[0])
-   1    log(x[1])
-   2    log(x[2])
-   3    log(x[3])
-   4    log(x[4])
+   >>> 1 / x
+   0    1.0 / x[0]
+   1    1.0 / x[1]
+   2    1.0 / x[2]
+   3    1.0 / x[3]
+   4    1.0 / x[4]
    Name: x, dtype: object
 
-Similarly, you can use operator overloading to construct other nonlinear
-expressions:
+The ``nlfunc`` module of gurobipy is used to create nonlinear expressions
+involving mathematical functions. You can use ``apply`` to construct a series
+representing the logarithm of the above result.
 
 .. doctest:: [nonlinear]
 
-   >>> x / y
-   0    x[0] / y[0]
-   1    x[1] / y[1]
-   2    x[2] / y[2]
-   3    x[3] / y[3]
-   4    x[4] / y[4]
-   dtype: object
+   >>> (1 / x).apply(nlfunc.log)
+   0    log(1.0 / x[0])
+   1    log(1.0 / x[1])
+   2    log(1.0 / x[2])
+   3    log(1.0 / x[3])
+   4    log(1.0 / x[4])
+   Name: x, dtype: object
 
-The resulting expressions can be added as constraints using ``add_constrs``.
+This series of expressions can be added as constraints using ``add_constrs``.
 Note that you can only provide nonlinear constraints in the form :math:`y =
-f(x)`. Therefore the ``lhs`` argument must be a series of ``Var`` objects, while
-the ``sense`` argument must be ``GRB.EQUAL``.
+f(\bar{x})` where :math:`f` may be a univariate or multivariate compound
+function. Therefore the ``lhs`` argument must be a series of ``Var`` objects,
+while the ``sense`` argument must be ``GRB.EQUAL``.
 
 .. doctest:: [nonlinear]
 
-   >>> gppd.add_constrs(model, y, GRB.EQUAL, x.apply(nlfunc.log), name="log_x")
+   >>> gppd.add_constrs(model, y, GRB.EQUAL, (1 / x).apply(nlfunc.log), name="log_x")
    0    <gurobi.GenConstr 0>
    1    <gurobi.GenConstr 1>
    2    <gurobi.GenConstr 2>
@@ -78,7 +81,7 @@ Nonlinear Inequality Constraints
 --------------------------------
 
 As noted above, nonlinear constraints can only be provided in the form :math:`y=
-f(x)`. To formulate inequality constraints, you must introduce bounded
+f(\bar{x})`. To formulate inequality constraints, you must introduce bounded
 intermediate variables. The following example formulates the set of constraints
 :math:`\log(x_i^2 + 1) \le 2` by introducing intermediate variables :math:`z_i`
 with no lower bound and an upper bound of :math:`2.0`.

--- a/docs/source/nonlinear.rst
+++ b/docs/source/nonlinear.rst
@@ -1,10 +1,19 @@
 Adding Nonlinear Constraints
 ============================
 
+Gurobi 12 supports adding nonlinear constraints, using the ``NLExpr`` object to
+capture nonlinear expressions. ``gurobipy-pandas`` supports adding a ``Series``
+of nonlinear constraints to a model via ``add_constrs``. Note that ``gurobipy``
+only supports nonlinear constraints of the form :math:`y = f(x)`, and
+``gurobipy-pandas`` applies the same restriction.
+
 .. note::
 
    To add nonlinear constraints, you must have at least ``gurobipy`` version
    12.0.0 installed.
+
+Nonlinear Equality Constraints
+------------------------------
 
 This example builds the constraint set :math:`y_i = \log(x_i)`, for each
 :math:`i` in the index.

--- a/docs/source/nonlinear.rst
+++ b/docs/source/nonlinear.rst
@@ -1,0 +1,66 @@
+Adding Nonlinear Constraints
+============================
+
+.. note::
+
+   To add nonlinear constraints, you must have at least ``gurobipy`` version
+   12.0.0 installed.
+
+This example builds the constraint set :math:`y_i = \log(x_i)`, for each
+:math:`i` in the index.
+
+.. doctest:: [nonlinear]
+
+    >>> import pandas as pd
+    >>> import gurobipy as gp
+    >>> from gurobipy import GRB
+    >>> from gurobipy import nlfunc
+    >>> import gurobipy_pandas as gppd
+    >>> gppd.set_interactive()
+
+    >>> model = gp.Model()
+    >>> index = pd.RangeIndex(5)
+    >>> x = gppd.add_vars(model, index, name="x")
+    >>> y = gppd.add_vars(model, index, name="y")
+
+The ``nlfunc`` module of gurobipy is used to create nonlinear expressions. You
+can use ``apply`` to construct a series representing the logarithm of each
+variable in the series:
+
+.. doctest:: [nonlinear]
+
+   >>> x.apply(nlfunc.log)
+   0    log(x[0])
+   1    log(x[1])
+   2    log(x[2])
+   3    log(x[3])
+   4    log(x[4])
+   Name: x, dtype: object
+
+Similarly, you can use operator overloading to construct other nonlinear
+expressions:
+
+.. doctest:: [nonlinear]
+
+   >>> x / y
+   0    x[0] / y[0]
+   1    x[1] / y[1]
+   2    x[2] / y[2]
+   3    x[3] / y[3]
+   4    x[4] / y[4]
+   dtype: object
+
+The resulting expressions can be added as constraints using ``add_constrs``.
+Note that you can only provide nonlinear constraints in the form :math:`y =
+f(x)`. Therefore the ``lhs`` argument must be a series of ``Var`` objects, while
+the ``sense`` argument must be ``GRB.EQUAL``.
+
+.. doctest:: [nonlinear]
+
+   >>> gppd.add_constrs(model, y, GRB.EQUAL, x.apply(nlfunc.log), name="log_x")
+   0    <gurobi.GenConstr 0>
+   1    <gurobi.GenConstr 1>
+   2    <gurobi.GenConstr 2>
+   3    <gurobi.GenConstr 3>
+   4    <gurobi.GenConstr 4>
+   Name: log_x, dtype: object

--- a/docs/source/nonlinear.rst
+++ b/docs/source/nonlinear.rst
@@ -64,3 +64,44 @@ the ``sense`` argument must be ``GRB.EQUAL``.
    3    <gurobi.GenConstr 3>
    4    <gurobi.GenConstr 4>
    Name: log_x, dtype: object
+
+Nonlinear Inequality Constraints
+--------------------------------
+
+As noted above, nonlinear constraints can only be provided in the form :math:`y=
+f(x)`. To formulate inequality constraints, you must introduce bounded
+intermediate variables. The following example formulates the set of constraints
+:math:`\log(x_i^2 + 1) \le 2` by introducing intermediate variables :math:`z_i`
+with no lower bound and an upper bound of :math:`2.0`.
+
+.. doctest:: [nonlinear]
+
+   >>> z = gppd.add_vars(model, index, lb=-GRB.INFINITY, ub=2.0, name="z")
+   >>> constrs = gppd.add_constrs(model, z, GRB.EQUAL, (x**2 + 1).apply(nlfunc.log))
+
+To see the effect of this constraint, you can set a maximization objective
+:math:`\sum_{i=0}^{4} x_i` and solve the resulting model. You will find that the
+original variables :math:`x_i` are maximized to :math:`\sqrt{e^2 - 1}` in
+the optimal solution. The intermediate variables :math:`z_i` are at their upper
+bounds, indicating that the constraint is satisfied with equality.
+
+.. doctest:: [nonlinear]
+
+   >>> model.setObjective(x.sum(), sense=GRB.MAXIMIZE)
+   >>> model.optimize()  # doctest: +ELLIPSIS
+   Gurobi Optimizer ...
+   Optimal solution found ...
+   >>> x.gppd.X.round(3)
+   0    2.528
+   1    2.528
+   2    2.528
+   3    2.528
+   4    2.528
+   Name: x, dtype: float64
+   >>> z.gppd.X.round(3)
+   0    2.0
+   1    2.0
+   2    2.0
+   3    2.0
+   4    2.0
+   Name: z, dtype: float64

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -330,6 +330,31 @@ class TestNonlinear(GurobiModelTestCase):
             self.assert_approx_equal(x_sol[i], math.sqrt(math.exp(2.0) - 1))
             self.assert_approx_equal(z_sol[i], 2.0)
 
+    def test_wrong_usage(self):
+        index = pd.RangeIndex(3)
+        x = gppd.add_vars(self.model, index, name="x")
+        y = gppd.add_vars(self.model, index, name="x")
+
+        with self.assertRaisesRegex(
+            gp.GurobiError, "Objective must be linear or quadratic"
+        ):
+            self.model.setObjective((x / y).sum())
+
+        with self.assertRaisesRegex(
+            ValueError, "Nonlinear constraints must be in the form"
+        ):
+            gppd.add_constrs(self.model, y, GRB.LESS_EQUAL, x**4)
+
+        with self.assertRaisesRegex(
+            ValueError, "Nonlinear constraints must be in the form"
+        ):
+            gppd.add_constrs(self.model, y + x**4, GRB.EQUAL, 1)
+
+        with self.assertRaisesRegex(
+            ValueError, "Nonlinear constraints must be in the form"
+        ):
+            gppd.add_constrs(self.model, y**4, GRB.EQUAL, x)
+
 
 class TestDataValidation(GurobiModelTestCase):
     # Test that we throw some more informative errors, instead of obscure

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,12 +3,18 @@ Tests for the public API. These are intentionally simple, more careful
 tests of data types, errors, etc, are done on the lower-level functions.
 """
 
+import math
+import unittest
+
+import gurobipy as gp
 import pandas as pd
 from gurobipy import GRB
 from pandas.testing import assert_index_equal, assert_series_equal
 
 import gurobipy_pandas as gppd
 from tests.utils import GurobiModelTestCase
+
+GUROBIPY_MAJOR_VERSION, *_ = gp.gurobi.version()
 
 
 class TestAddVars(GurobiModelTestCase):
@@ -267,6 +273,62 @@ class TestAddConstrs(GurobiModelTestCase):
             )
             self.assertEqual(constr.Sense, sense)
             self.assertEqual(constr.RHS, -1.0)
+
+
+@unittest.skipIf(
+    GUROBIPY_MAJOR_VERSION < 12,
+    "Nonlinear constraints are only supported for Gurobi 12 and later",
+)
+class TestNonlinear(GurobiModelTestCase):
+    def assert_approx_equal(self, value, expected, tolerance=1e-6):
+        difference = abs(value - expected)
+        self.assertLessEqual(difference, tolerance)
+
+    def test_log(self):
+        # max sum y_i
+        # s.t. y_i = log(x_i)
+        #      1.0 <= x <= 2.0
+        from gurobipy import nlfunc
+
+        index = pd.RangeIndex(3)
+        x = gppd.add_vars(self.model, index, lb=1.0, ub=2.0, name="x")
+        y = gppd.add_vars(self.model, index, obj=1.0, name="y")
+        self.model.ModelSense = GRB.MAXIMIZE
+
+        gppd.add_constrs(self.model, y, GRB.EQUAL, x.apply(nlfunc.log), name="log_x")
+
+        self.model.optimize()
+        self.assert_approx_equal(self.model.ObjVal, 3 * math.log(2.0))
+
+    def test_inequality(self):
+        # max  sum x_i
+        # s.t. log2(x_i^2 + 1) <= 2.0
+        #      0.0 <= x <= 1.0
+        #
+        # Formulated as
+        #
+        # max  sum x_i
+        # s.t. log2(x_i^2 + 1) == z_i
+        #      0.0 <= x <= 1.0
+        #      -GRB.INFINITY <= z_i <= 2
+        from gurobipy import nlfunc
+
+        index = pd.RangeIndex(3)
+        x = gppd.add_vars(self.model, index, name="x")
+        z = gppd.add_vars(self.model, index, lb=-GRB.INFINITY, ub=2.0, name="z")
+        self.model.setObjective(x.sum(), sense=GRB.MAXIMIZE)
+
+        gppd.add_constrs(self.model, z, GRB.EQUAL, (x**2 + 1).apply(nlfunc.log))
+
+        self.model.optimize()
+        self.model.write("model.lp")
+        self.model.write("model.sol")
+
+        x_sol = x.gppd.X
+        z_sol = z.gppd.X
+        for i in range(3):
+            self.assert_approx_equal(x_sol[i], math.sqrt(math.exp(2.0) - 1))
+            self.assert_approx_equal(z_sol[i], 2.0)
 
 
 class TestDataValidation(GurobiModelTestCase):

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -31,5 +31,7 @@ def load_tests(loader, tests, ignore):
     here = pathlib.Path(__file__).parent
     docs = here.joinpath("../docs/source")
     for docfile in docs.rglob("*.rst"):
+        if docfile.stem == "nonlinear" and GUROBIPY_MAJOR_VERSION < 12:
+            continue
         tests.addTests(doctest.DocFileSuite(str(docfile.relative_to(here))))
     return tests

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import unittest
 
 import gurobipy as gp
+from gurobipy import GRB
 
 
 class GurobiModelTestCase(unittest.TestCase):
@@ -36,3 +37,18 @@ class GurobiModelTestCase(unittest.TestCase):
             self.assertTrue(expr1.getVar1(i).sameAs(expr2.getVar1(i)))
             self.assertTrue(expr1.getVar2(i).sameAs(expr2.getVar2(i)))
             self.assertEqual(expr1.getCoeff(i), expr2.getCoeff(i))
+
+    def assert_nlconstr_equal(self, genconstr, resvar_true, tree):
+        resvar, opcode_array, data_array, parent_array = self.model.getGenConstrNLAdv(
+            genconstr
+        )
+        self.assertIs(resvar, resvar_true)
+        for opcode, data, parent, (opcode_true, data_true, parent_true) in zip(
+            opcode_array, data_array, parent_array, tree
+        ):
+            self.assertEqual(opcode, opcode_true)
+            if opcode == GRB.OPCODE_VARIABLE:
+                self.assertIs(data, data_true)
+            else:
+                self.assertEqual(data, data_true)
+            self.assertEqual(parent, parent_true)


### PR DESCRIPTION
Adds support for constraints of the form y = f(x) for nonlinear functions representable as NLExprs in gurobipy v12. Adds a new documentation page showing correct usage, and examples showing how to use intermediate variables to work around the equality constraint restriction.

Closes #93