### PR TITLE
Note support for Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: Implementation :: CPython",
 ]


### PR DESCRIPTION
No changes required to gurobipy-pandas. Note that Python 3.13 is only supported by gurobipy 12.0.1 and later.